### PR TITLE
Fix drawing

### DIFF
--- a/Pidgin MacOS Integration/plugin_load.h
+++ b/Pidgin MacOS Integration/plugin_load.h
@@ -30,7 +30,7 @@ void plugin_unload_oc(PurplePlugin *plugin);
 void plugin_init_oc(PurplePlugin *plugin);
 
 void (*conv_test(void))(void);
-
+char* get_list_value_string(GtkTreeModel* model, GtkTreeIter* iter, gint column);
 
 struct im_image_data {
     int id;

--- a/Pidgin MacOS Integration/plugin_load.h
+++ b/Pidgin MacOS Integration/plugin_load.h
@@ -19,6 +19,8 @@ void register_callback_to_modify(PurplePlugin *plugin, gboolean (*function)(Purp
 void register_callback(PurplePlugin *plugin, gboolean (*function)(PurpleAccount *, char *, char *, PurpleConversation *, PurpleMessageFlags *), const char* callback);
 void register_conversation_created_callback(PurplePlugin *plugin, gboolean (*function)(PurpleConversation *, void *), const char* callback, void *data);
 void register_buddy_list_created_callback(PurplePlugin *plugin, gboolean (*function)(PurpleBuddyList *, void *), const char* callback, void *data);
+void register_switch_page_callback(GtkWidget *notebook, const char* callback, GtkWidget *window, gboolean function (GtkWidget *notebook, GtkNotebookPage *notebook_page, int page, GtkWidget *data));
+void register_configuration_event_callback(GtkWidget *window, gboolean function (GtkWidget *widget, GdkEvent  *event, gpointer user_data));
 void set_menu(GtkWidget *menu);
 GtkWindow* to_window(void* obj);
 

--- a/Pidgin MacOS Integration/plugin_load.m
+++ b/Pidgin MacOS Integration/plugin_load.m
@@ -76,7 +76,27 @@ void register_conversation_created_callback(PurplePlugin *plugin, gboolean (*fun
 void register_buddy_list_created_callback(PurplePlugin *plugin, gboolean (*function)(PurpleBuddyList *, void *), const char* callback, void *data) {
     log_callback("macos", "Registering callback %s for conversation...\n", callback);
     purple_signal_connect(pidgin_blist_get_handle(), callback, plugin, PURPLE_CALLBACK(function), data);
-    log_all("macos", "Registered\n");
+    log_all("macos", "Registered");
+}
+
+void register_switch_page_callback(GtkWidget *notebook, const char* callback, GtkWidget *window, gboolean function (GtkWidget *notebook, GtkNotebookPage *notebook_page, int page, GtkWidget *data)) {
+    log_callback("macos", "Registering %s callback for window...\n", callback);
+    if(g_signal_connect_after(G_OBJECT(notebook), callback, G_CALLBACK(function), window)) {
+        log_all("macos", "Success.");
+    }
+    else {
+        log_all("macos", "Failure.");
+    }
+}
+
+void register_configuration_event_callback(GtkWidget *window, gboolean function (GtkWidget *widget, GdkEvent  *event, gpointer user_data)) {
+    log_all("macos", "Registering configure-event callback for window...");
+    if(g_signal_connect_after(G_OBJECT(window), "configure-event", G_CALLBACK(function), NULL)) {
+        log_all("macos", "Success.");
+    }
+    else {
+        log_all("macos", "Failure.");
+    }
 }
 
 void log_callback(const char* category, const char* message, const char* callback) {

--- a/Pidgin MacOS Integration/plugin_load.m
+++ b/Pidgin MacOS Integration/plugin_load.m
@@ -97,6 +97,14 @@ void set_menu(GtkWidget *menu){
     gtkosx_application_set_menu_bar(gtkosx_application_get(), GTK_MENU_SHELL(menu));
 }
 
+char* get_list_value_string(GtkTreeModel* model, GtkTreeIter* iter, gint column) {
+    gchar* value = NULL;
+    gtk_tree_model_get_value(model, iter, column, value);
+    g_free(value);
+    gtk_tree_model_get(model, iter, 0, value, -1);
+    return value;
+}
+
 GtkWindow* to_window(void* obj) {
     return GTK_WINDOW(obj);
 }


### PR DESCRIPTION
Workaround (partial) for [GTK Mojave redrawing issue](https://gitlab.gnome.org/GNOME/gtk/issues/1479).

Conversation window properly redraws on new conversation open, switch conversation events. Still not working correctly for closing conversation (even though redraw is called).